### PR TITLE
Add Windows support.

### DIFF
--- a/lib/modularize.js
+++ b/lib/modularize.js
@@ -4,8 +4,14 @@
  * https://github.com/scottbrady/dustjs-loader/blob/master/LICENSE
  */
 
+function escape(name) {
+  return name.replace(/\\/g, '\\\\');
+}
+
 module.exports = {
   wrap: function(name, template) {
+    name = escape(name);
+
     return "" +
       "(function() {\n" +
       "var dust = require('dustjs-linkedin');\n" +
@@ -21,6 +27,8 @@ module.exports = {
     if (promises && promises !== true) {
       promisesRequire = "var Promise = require('" + promises + "');\n";
     }
+
+    name = escape(name);
 
     return "" +
       "(function() {\n" +

--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
   },
   "homepage": "https://github.com/alexgorbatchev/dustify",
   "dependencies": {
-    "dustjs-linkedin": "^2.7.0",
-    "through": "^2.3.6"
+    "dustjs-linkedin": "^2.7.4",
+    "through": "^2.3.8"
   },
   "devDependencies": {
-    "bluebird": "^2.9.25",
-    "browserify": "^10.1.3",
-    "chai": "^2.3.0",
-    "mocha": "^2.2.4"
+    "bluebird": "^3.4.6",
+    "browserify": "^13.1.1",
+    "chai": "^3.5.0",
+    "mocha": "^3.1.2"
   }
 }


### PR DESCRIPTION
Windows paths have backslashes used by the Node.js `path` library.

Support for Windows systems has been added by escaping these backslashes with slashes of the rear-facing variety.