### PR TITLE
Fix Windows support for partial references.

### DIFF
--- a/lib/dustify.js
+++ b/lib/dustify.js
@@ -53,7 +53,7 @@ module.exports = function (filename, options) {
       name = name.replace(path.join(options.path, '/'), '');
     }
 
-    name = name.replace(path.extname(name), '');
+    name = name.replace(path.extname(name), '').replace(/\\/g, '/');
     template = dust.compile(source, name);
 
     // find all references to partials
@@ -63,6 +63,8 @@ module.exports = function (filename, options) {
         path.dirname(filename),
         path.join(process.cwd(), options.path ? options.path : '', childTemplate)
       );
+      
+      childTemplatePath = childTemplatePath.replace(/\\/g, '\\\\');
 
       if (childTemplatePath[0] !== '.') {
         childTemplatePath = './' + childTemplatePath;

--- a/test/dustify.spec.js
+++ b/test/dustify.spec.js
@@ -52,4 +52,26 @@ describe('dustify', function () {
       expect(results).to.equal('Hello Alex!');
     });
   })
+
+  describe('partials', function () {
+    beforeEach(function (done) {
+      var testBundle = browserify();
+      testBundle.transform(dustify);
+      testBundle.add(__dirname + '/partials.js');
+
+      testBundle.bundle(function (err, value) {
+        var context = {
+          done: function (err, html) {
+            results = html;
+            done(err);
+          }
+        };
+        vm.runInNewContext(value, context);
+      });
+    });
+
+    it('returns correct results', function () {
+      expect(results).to.equal('Hello Alex!');
+    });
+  })
 });

--- a/test/fixture-partials.dust
+++ b/test/fixture-partials.dust
@@ -1,0 +1,1 @@
+{> "test/fixture" /}

--- a/test/partials.js
+++ b/test/partials.js
@@ -1,0 +1,2 @@
+var template = require('./fixture-partials.dust');
+template({name: "Alex"}, done);


### PR DESCRIPTION
Forces template names into POSIX form, and escapes backslashes in module names.